### PR TITLE
feat: production-readiness — live task handlers, resolved in-app templates, fail-fast validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING:** Default channels changed from `['email', 'whatsapp', 'sms', 'inapp']` to `['email', 'inapp']`. SMS and WhatsApp must now be explicitly enabled with provider credentials.
+- **BREAKING:** Configuration validation now runs at plugin creation time (fail-fast). Invalid configs that previously failed silently at runtime now throw immediately with clear `payload-notifications:` prefixed error messages.
+- **BREAKING:** In-app notifications now persist resolved template `title` and `message` with token replacement instead of generic placeholder text.
+- Task handlers are now wired as live handlers via `onInit` and work out of the box without host-app overrides. The deferred handler pattern has been removed.
+- All validation error messages now use a consistent `payload-notifications:` prefix.
+
+### Added
+- Live task handler registration through plugin `onInit` hook — jobs execute without host-app wiring
+- `validateNormalizedOptions()` is called automatically during plugin creation
+- Validation for unknown channel names
+- Validation for empty channels array
+- Twilio WhatsApp credential validation (accountSid, authToken, from)
+- In-app channel resolves and renders template `title` and `body` fields with token replacement
+- Tests for live task handler execution, pre-init failure, onInit chaining, in-app template resolution, and expanded config validation
+- Documentation for jobs processing, serverless constraints, and migration from 0.1.x
+
+### Fixed
+- Task handlers no longer return a `state: 'failed'` deferred error — they execute the real job logic after initialization
+
+## [0.1.1] - 2026-03-26
+
 ### Added
 - Initial project structure
 - Core plugin configuration

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Production-ready notifications plugin for Payload CMS with an event-driven, mult
 ## Features
 - Event-to-rule notification dispatch through Payload jobs
 - Channel implementations for email, WhatsApp, SMS, and in-app notifications
-- Delivery log persistence and in-app notification storage
+- Delivery log persistence and in-app notification storage with resolved template content
 - Template registry and resolution utilities with starter transactional templates
 - Preference mapping, consent enforcement, and custom policy hooks
 - Reliability helpers for idempotency, retry classification, retry-safe dispatch behavior, and observability hooks
+- Fail-fast configuration validation with clear error messages
 - Bun-based test suite, contributor guidance, CI expectations, and release-readiness docs
 
 ## Installation
@@ -20,12 +21,43 @@ bun add @wtree/payload-notifications
 ```ts
 import { notificationsPlugin } from '@wtree/payload-notifications'
 
-export default notificationsPlugin({
+export default buildConfig({
+  plugins: [
+    notificationsPlugin({
+      channels: ['email', 'inapp'],
+      providers: {
+        email: {
+          defaultFromAddress: 'noreply@example.com',
+        },
+      },
+      rules: [
+        {
+          event: 'order.paid',
+          channels: ['email', 'inapp'],
+          template: 'order.paid',
+        },
+      ],
+      observability: {
+        onDispatch: async (event) => {
+          console.info(event)
+        },
+      },
+    }),
+  ],
+})
+```
+
+## Configuration
+### Channels
+
+Default channels: `['email', 'inapp']`. These work out of the box with Payload's built-in email adapter and the notifications collection.
+
+To enable SMS or WhatsApp, you must explicitly add them and provide provider credentials:
+
+```ts
+notificationsPlugin({
   channels: ['email', 'sms', 'inapp'],
   providers: {
-    email: {
-      defaultFromAddress: 'noreply@example.com',
-    },
     sms: {
       provider: 'twilio',
       accountSid: process.env.TWILIO_ACCOUNT_SID,
@@ -33,34 +65,24 @@ export default notificationsPlugin({
       from: process.env.TWILIO_SMS_FROM,
     },
   },
-  observability: {
-    onDispatch: async (event) => {
-      console.info(event)
-    },
-  },
-  templates: {
-    registry: {
-      'order.paid': {
-        email: {
-          subject: 'Order {{ payload.orderId }} paid',
-          body: 'Hi {{ userId }}, order {{ payload.orderId }} is now paid.',
-        },
-        sms: 'Order {{ payload.orderId }} is paid.',
-      },
-    },
-  },
 })
 ```
 
-## Configuration
-### Channels
-- `email`
-- `whatsapp`
-- `sms`
-- `inapp`
+Available channels: `email`, `whatsapp`, `sms`, `inapp`.
+
+### Jobs processing
+
+The plugin registers two Payload job tasks automatically:
+
+- `notification:process-event` — routes events to matching rules and queues per-channel sends
+- `notification:send` — dispatches individual notifications to channels
+
+Task handlers are wired up via the plugin's `onInit` hook and work out of the box. No host-app overrides are required.
+
+**Serverless environments:** Payload's job runner processes queued tasks. In serverless deployments (Vercel, AWS Lambda), you may need to configure an external job runner or use Payload's `autoRunJobs` option to ensure background tasks execute. See Payload's [jobs documentation](https://payloadcms.com/docs/jobs-queue/overview) for platform-specific guidance.
 
 ### Template registry
-Templates resolve by event key and channel, and can be overridden without modifying core internals.
+Templates resolve by event key and channel, and can be overridden without modifying core internals. In-app notifications persist the resolved and token-replaced `title` and `body` from the template definition.
 
 ```ts
 const config = {
@@ -71,12 +93,18 @@ const config = {
           subject: 'Order {{ payload.orderId }} shipped',
           body: 'Tracking: {{ payload.trackingNumber }}',
         },
+        inapp: {
+          title: 'Order shipped',
+          body: 'Order {{ payload.orderId }} has shipped.',
+        },
         whatsapp: 'Order {{ payload.orderId }} shipped. Tracking {{ payload.trackingNumber }}.',
       },
     },
   },
 }
 ```
+
+Supported tokens: `{{ event }}`, `{{ userId }}`, `{{ payload.key }}` (supports dot-notation for nested values).
 
 ### Preferences, policy, and observability
 ```ts
@@ -124,7 +152,22 @@ Starter templates are included for:
 - `order.shipped`
 - `auth.magic-link`
 
-## Migration
+## SMS and WhatsApp providers
+
+SMS and WhatsApp channels currently use mock provider adapters that return deterministic message IDs. Real Twilio and Meta integrations are planned for a follow-up release. The adapter pattern (`createSMSProvider`, `createWhatsAppProvider`) is ready for drop-in replacement.
+
+## Migration from 0.1.x
+
+### Breaking changes
+
+1. **Default channels changed** from `['email', 'whatsapp', 'sms', 'inapp']` to `['email', 'inapp']`. If you relied on the old defaults, explicitly pass the channels you need.
+
+2. **Fail-fast validation** is now run at plugin creation time. Previously, some invalid configurations (like enabling SMS without a provider) would only fail at runtime. Now they throw immediately with a `payload-notifications:` prefixed message.
+
+3. **In-app notification content** now stores resolved template `title` and `message` instead of generic placeholders. If you parse stored notification text, update any expectations.
+
+### Migration steps
+
 If you currently send notifications directly from hooks or services, migrate by:
 1. Emitting domain events into the plugin job pipeline.
 2. Moving per-channel message text into the template registry.

--- a/src/channels/inapp.ts
+++ b/src/channels/inapp.ts
@@ -3,23 +3,46 @@ import type {
   NormalizedNotificationsPluginOptions,
   NotificationDispatchResult,
   NotificationSendInput,
+  NotificationTemplateContext,
+  NotificationTemplateDefinition,
 } from '../types'
+import { renderTemplate } from '../templates/render'
 
 export const sendInAppNotification = async ({
   payload,
   input,
   options,
+  resolvedDefinition,
 }: {
   payload: Payload
   input: NotificationSendInput
   options: NormalizedNotificationsPluginOptions
+  resolvedDefinition?: NotificationTemplateDefinition
 }): Promise<NotificationDispatchResult> => {
   try {
+    const context: NotificationTemplateContext = {
+      event: input.event,
+      userId: input.userId,
+      payload: input.eventPayload,
+    }
+
+    let title = `Notification: ${input.event}`
+    let message = input.template
+
+    if (resolvedDefinition) {
+      if (resolvedDefinition.title) {
+        title = (await renderTemplate(resolvedDefinition.title, context)).text || title
+      }
+      if (resolvedDefinition.body) {
+        message = (await renderTemplate(resolvedDefinition.body, context)).text || message
+      }
+    }
+
     await payload.create({
       collection: options.collections.notifications,
       data: {
-        title: `Notification for ${input.event}`,
-        message: `Template ${input.template} stored for ${input.event}`,
+        title,
+        message,
         recipient: input.userId,
         meta: {
           data: input.eventPayload,

--- a/src/config/normalizePluginOptions.ts
+++ b/src/config/normalizePluginOptions.ts
@@ -1,17 +1,26 @@
 import type { NotificationsPluginOptions, NormalizedNotificationsPluginOptions } from '../types'
 import { getDefaultTemplateRegistry } from '../templates/context'
 
-const DEFAULT_CHANNELS: NormalizedNotificationsPluginOptions['channels'] = [
-  'email',
-  'whatsapp',
-  'sms',
-  'inapp',
-]
+/**
+ * Safe defaults: only channels that work without external provider config.
+ * Email uses Payload's built-in adapter; inapp uses the notifications collection.
+ * Users must explicitly opt in to sms/whatsapp (which require provider credentials).
+ *
+ * BREAKING CHANGE from 0.1.x: default channels changed from
+ * ['email', 'whatsapp', 'sms', 'inapp'] to ['email', 'inapp'].
+ */
+const DEFAULT_CHANNELS: NormalizedNotificationsPluginOptions['channels'] = ['email', 'inapp']
+
+const VALID_CHANNELS = new Set(['email', 'whatsapp', 'sms', 'inapp', 'push'])
 
 export const normalizePluginOptions = (
   options: NotificationsPluginOptions = {},
 ): NormalizedNotificationsPluginOptions => {
   const userProvidedChannels = options.channels !== undefined
+
+  if (userProvidedChannels && options.channels?.length === 0) {
+    throw new Error('payload-notifications: at least one channel must be enabled')
+  }
 
   const channels =
     userProvidedChannels && options.channels?.length
@@ -22,26 +31,47 @@ export const normalizePluginOptions = (
   const logsSlug = options.collections?.logs || 'notification-logs'
 
   if (notificationsSlug === logsSlug) {
-    throw new Error('notifications and logs collections must use different slugs')
+    throw new Error(
+      'payload-notifications: notifications and logs collections must use different slugs',
+    )
   }
 
-  if (
-    userProvidedChannels &&
-    channels.includes('whatsapp') &&
-    !options.providers?.whatsapp?.provider
-  ) {
-    throw new Error('providers.whatsapp.provider is required')
+  for (const ch of channels) {
+    if (!VALID_CHANNELS.has(ch)) {
+      throw new Error(`payload-notifications: unknown channel "${ch}"`)
+    }
   }
 
-  if (
-    userProvidedChannels &&
-    channels.includes('sms') &&
-    options.providers?.sms?.provider === 'twilio'
-  ) {
+  if (channels.includes('whatsapp') && !options.providers?.whatsapp?.provider) {
+    throw new Error(
+      'payload-notifications: providers.whatsapp.provider is required when whatsapp channel is enabled',
+    )
+  }
+
+  if (channels.includes('sms') && !options.providers?.sms?.provider) {
+    throw new Error(
+      'payload-notifications: providers.sms.provider is required when sms channel is enabled',
+    )
+  }
+
+  if (channels.includes('sms') && options.providers?.sms?.provider === 'twilio') {
     const smsConfig = options.providers.sms
     if (!smsConfig.accountSid || !smsConfig.authToken || !smsConfig.from) {
-      throw new Error('Twilio SMS requires accountSid, authToken, and from')
+      throw new Error('payload-notifications: Twilio SMS requires accountSid, authToken, and from')
     }
+  }
+
+  if (channels.includes('whatsapp') && options.providers?.whatsapp?.provider === 'twilio') {
+    const waConfig = options.providers.whatsapp
+    if (!waConfig.accountSid || !waConfig.authToken || !waConfig.from) {
+      throw new Error(
+        'payload-notifications: Twilio WhatsApp requires accountSid, authToken, and from',
+      )
+    }
+  }
+
+  if (!channels.length) {
+    throw new Error('payload-notifications: at least one channel must be enabled')
   }
 
   return {
@@ -83,6 +113,11 @@ export const normalizePluginOptions = (
   }
 }
 
+/**
+ * Validates a normalized options object. Called automatically by
+ * `notificationsPlugin()`. Exported for use when building options
+ * programmatically outside the plugin entry point.
+ */
 export const validateNormalizedOptions = (
   options: NormalizedNotificationsPluginOptions,
 ): NormalizedNotificationsPluginOptions => {
@@ -93,6 +128,12 @@ export const validateNormalizedOptions = (
   if (options.channels.includes('sms') && !options.providers.sms?.provider) {
     throw new Error(
       'payload-notifications: providers.sms.provider is required when sms channel is enabled',
+    )
+  }
+
+  if (options.channels.includes('whatsapp') && !options.providers.whatsapp?.provider) {
+    throw new Error(
+      'payload-notifications: providers.whatsapp.provider is required when whatsapp channel is enabled',
     )
   }
 

--- a/src/jobs/sendNotification.ts
+++ b/src/jobs/sendNotification.ts
@@ -255,25 +255,31 @@ export const sendNotification = async ({
     options,
   })
 
-  const sendInput = {
-    ...validatedInput,
-    template: resolved.definition.body,
-  }
-
   let result: NotificationDispatchResult | void
 
   switch (validatedInput.channel) {
-    case 'email':
+    case 'email': {
+      const sendInput = { ...validatedInput, template: resolved.definition.body }
       result = await sendEmailNotification({ payload, input: sendInput, options })
       break
-    case 'whatsapp':
+    }
+    case 'whatsapp': {
+      const sendInput = { ...validatedInput, template: resolved.definition.body }
       result = await sendWhatsAppNotification({ payload, input: sendInput, options })
       break
-    case 'sms':
+    }
+    case 'sms': {
+      const sendInput = { ...validatedInput, template: resolved.definition.body }
       result = await sendSMSNotification({ payload, input: sendInput, options })
       break
+    }
     case 'inapp':
-      result = await sendInAppNotification({ payload, input: sendInput, options })
+      result = await sendInAppNotification({
+        payload,
+        input: validatedInput,
+        options,
+        resolvedDefinition: resolved.definition,
+      })
       break
     default:
       throw new Error(`Unsupported notification channel: ${validatedInput.channel}`)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,7 +5,7 @@ import type {
   NotificationQueueTask,
   NotificationsPluginOptions,
 } from './types'
-import type { TaskConfig, TaskHandler, TaskHandlerArgs, TaskHandlerResult } from 'payload'
+import type { TaskConfig, TaskHandler, TaskHandlerResult } from 'payload'
 import {
   NotificationsCollection,
   type NotificationsCollectionOverrides,
@@ -14,15 +14,13 @@ import {
   NotificationLogsCollection,
   type NotificationLogsCollectionOverrides,
 } from './collections/NotificationLogs'
-import { normalizePluginOptions } from './config/normalizePluginOptions'
+import { normalizePluginOptions, validateNormalizedOptions } from './config/normalizePluginOptions'
 import { assertNotificationEvent, processEvent } from './jobs/processEvent'
 import { assertNotificationSendInput, sendNotification } from './jobs/sendNotification'
 
 const hasCollectionSlug = (collections: CollectionConfig[] = [], slug: string): boolean => {
   return collections.some((collection) => collection.slug === slug)
 }
-
-type RegisteredTask = Pick<TaskConfig<any>, 'slug' | 'handler'>
 
 const getExistingTaskSlugs = (config: Config): string[] => {
   const jobsConfig = config.jobs
@@ -35,18 +33,48 @@ const getExistingTaskSlugs = (config: Config): string[] => {
     .filter(Boolean)
 }
 
-const createDeferredTaskHandler = (taskSlug: string): TaskHandler<any> => {
-  return async (args: TaskHandlerArgs<any>) => {
-    return {
-      state: 'failed',
-      errorMessage: `payload-notifications: task ${taskSlug} must be executed through registered plugin runtime`,
-    } as TaskHandlerResult<any>
+/**
+ * Holds a mutable reference that is populated by onInit once the Payload
+ * instance is available. Task handlers close over this so they work out of
+ * the box without host-app wiring.
+ */
+type RuntimeRef = {
+  payload: Payload | null
+  options: NormalizedNotificationsPluginOptions
+}
+
+const createLiveTaskHandler = (
+  taskSlug: 'notification:process-event' | 'notification:send',
+  runtime: RuntimeRef,
+): TaskHandler<any> => {
+  return async ({ input }: { input?: unknown }) => {
+    if (!runtime.payload) {
+      return {
+        state: 'failed',
+        errorMessage: `payload-notifications: task ${taskSlug} cannot run before plugin initialization`,
+      } as TaskHandlerResult<any>
+    }
+
+    if (taskSlug === 'notification:process-event') {
+      const event = assertNotificationEvent(input)
+      await processEvent({ payload: runtime.payload, event, options: runtime.options })
+      return { output: {} } as TaskHandlerResult<any>
+    }
+
+    const sendInput = assertNotificationSendInput(input)
+    const result = await sendNotification({
+      payload: runtime.payload,
+      input: sendInput,
+      options: runtime.options,
+    })
+    return { output: result ?? {} } as TaskHandlerResult<any>
   }
 }
 
 const registerTaskDefinitions = (
   config: Config,
   tasks: NotificationQueueTask[],
+  runtime: RuntimeRef,
 ): TaskConfig<any>[] => {
   const existing = new Set(getExistingTaskSlugs(config))
   const nextTasks: TaskConfig<any>[] =
@@ -59,7 +87,7 @@ const registerTaskDefinitions = (
 
     nextTasks.push({
       slug: task.slug,
-      handler: createDeferredTaskHandler(task.slug),
+      handler: createLiveTaskHandler(task.slug, runtime),
     } as TaskConfig<any>)
 
     existing.add(task.slug)
@@ -70,6 +98,9 @@ const registerTaskDefinitions = (
 
 export const notificationsPlugin = (options: NotificationsPluginOptions = {}) => {
   const normalizedOptions = normalizePluginOptions(options)
+  validateNormalizedOptions(normalizedOptions)
+
+  const runtime: RuntimeRef = { payload: null, options: normalizedOptions }
 
   return (config: Config): Config => {
     if (normalizedOptions.enabled === false) {
@@ -78,10 +109,13 @@ export const notificationsPlugin = (options: NotificationsPluginOptions = {}) =>
 
     const collections = [...(config.collections || [])]
     const withCollections = registerCollections(collections, normalizedOptions)
-    const tasks = registerTaskDefinitions(config, [
-      { slug: 'notification:process-event' },
-      { slug: 'notification:send' },
-    ])
+    const tasks = registerTaskDefinitions(
+      config,
+      [{ slug: 'notification:process-event' }, { slug: 'notification:send' }],
+      runtime,
+    )
+
+    const existingOnInit = config.onInit
 
     return {
       ...config,
@@ -89,6 +123,12 @@ export const notificationsPlugin = (options: NotificationsPluginOptions = {}) =>
       jobs: {
         ...config.jobs,
         tasks,
+      },
+      onInit: async (payload: Payload) => {
+        runtime.payload = payload
+        if (existingOnInit) {
+          await existingOnInit(payload)
+        }
       },
     }
   }
@@ -127,7 +167,22 @@ export const registerCollections = (
   return next
 }
 
-export const registerNotificationTasks = registerTaskDefinitions
+/**
+ * Public API for registering notification task definitions.
+ * Uses a standalone runtime ref — tasks registered this way will need
+ * `createTaskHandlers()` to execute. For automatic handler wiring,
+ * use `notificationsPlugin()` which sets up handlers via onInit.
+ */
+export const registerNotificationTasks = (
+  config: Config,
+  tasks: NotificationQueueTask[],
+): TaskConfig<any>[] => {
+  const standaloneRuntime: RuntimeRef = {
+    payload: null,
+    options: normalizePluginOptions(),
+  }
+  return registerTaskDefinitions(config, tasks, standaloneRuntime)
+}
 
 export const createTaskHandlers = (
   payload: Payload,

--- a/tests/channels.test.ts
+++ b/tests/channels.test.ts
@@ -206,6 +206,14 @@ describe('channel implementations', () => {
       },
       options: normalizePluginOptions({
         channels: ['sms'],
+        providers: {
+          sms: {
+            provider: 'twilio',
+            accountSid: 'sid',
+            authToken: 'token',
+            from: '+15551111111',
+          },
+        },
       }),
     })
 
@@ -234,6 +242,14 @@ describe('channel implementations', () => {
       },
       options: normalizePluginOptions({
         channels: ['sms'],
+        providers: {
+          sms: {
+            provider: 'twilio',
+            accountSid: 'sid',
+            authToken: 'token',
+            from: '+15551111111',
+          },
+        },
       }),
     })
 
@@ -244,9 +260,13 @@ describe('channel implementations', () => {
     expect(payload.create).toHaveBeenCalledTimes(1)
   })
 
-  it('stores in-app notifications and returns stored result', async () => {
+  it('stores in-app notifications with resolved template and returns stored result', async () => {
+    const createCalls: any[] = []
     const payload = createMockPayload({
-      create: mock(async () => undefined),
+      create: mock(async (args: any) => {
+        createCalls.push(args)
+        return undefined
+      }),
     })
 
     const result = await sendInAppNotification({
@@ -254,14 +274,49 @@ describe('channel implementations', () => {
       input: {
         userId: 'user_1',
         channel: 'inapp',
-        template: 'order-paid',
+        template: 'order.paid',
+        event: 'order.paid',
+        eventPayload: { orderId: 'ORD-789' },
+      },
+      options: normalizePluginOptions(),
+      resolvedDefinition: {
+        title: 'Order paid',
+        body: 'Order {{ payload.orderId }} is now marked as paid.',
+      },
+    })
+
+    expect(result.status).toBe('stored')
+    expect(payload.create).toHaveBeenCalledTimes(2)
+    // Verify the notification record has the resolved content
+    const notifData = createCalls[0]?.data
+    expect(notifData.title).toBe('Order paid')
+    expect(notifData.message).toBe('Order ORD-789 is now marked as paid.')
+  })
+
+  it('stores in-app with generic fallback when no resolvedDefinition', async () => {
+    const createCalls: any[] = []
+    const payload = createMockPayload({
+      create: mock(async (args: any) => {
+        createCalls.push(args)
+        return undefined
+      }),
+    })
+
+    const result = await sendInAppNotification({
+      payload: payload as never,
+      input: {
+        userId: 'user_1',
+        channel: 'inapp',
+        template: 'some-template',
         event: 'order.paid',
       },
       options: normalizePluginOptions(),
     })
 
     expect(result.status).toBe('stored')
-    expect(payload.create).toHaveBeenCalledTimes(2)
+    const notifData = createCalls[0]?.data
+    expect(notifData.title).toBe('Notification: order.paid')
+    expect(notifData.message).toBe('some-template')
   })
 
   it('returns failed in-app result when create throws', async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,7 +6,7 @@ describe('normalizePluginOptions', () => {
     const normalized = normalizePluginOptions()
 
     expect(normalized.enabled).toBe(true)
-    expect(normalized.channels).toEqual(['email', 'whatsapp', 'sms', 'inapp'])
+    expect(normalized.channels).toEqual(['email', 'inapp'])
     expect(normalized.userCollectionSlug).toBe('users')
     expect(normalized.collections.notifications).toBe('notifications')
     expect(normalized.collections.logs).toBe('notification-logs')
@@ -45,7 +45,7 @@ describe('normalizePluginOptions', () => {
           logs: 'same',
         },
       }),
-    ).toThrow('notifications and logs collections must use different slugs')
+    ).toThrow('payload-notifications: notifications and logs collections must use different slugs')
   })
 
   it('throws when whatsapp is enabled without provider', () => {
@@ -53,7 +53,19 @@ describe('normalizePluginOptions', () => {
       normalizePluginOptions({
         channels: ['whatsapp'],
       }),
-    ).toThrow('providers.whatsapp.provider is required')
+    ).toThrow(
+      'payload-notifications: providers.whatsapp.provider is required when whatsapp channel is enabled',
+    )
+  })
+
+  it('throws when sms is enabled without provider', () => {
+    expect(() =>
+      normalizePluginOptions({
+        channels: ['sms'],
+      }),
+    ).toThrow(
+      'payload-notifications: providers.sms.provider is required when sms channel is enabled',
+    )
   })
 
   it('throws when sms twilio config is incomplete', () => {
@@ -67,6 +79,22 @@ describe('normalizePluginOptions', () => {
           },
         },
       }),
-    ).toThrow('Twilio SMS requires accountSid, authToken, and from')
+    ).toThrow('payload-notifications: Twilio SMS requires accountSid, authToken, and from')
+  })
+
+  it('throws for unknown channels', () => {
+    expect(() =>
+      normalizePluginOptions({
+        channels: ['pigeon' as any],
+      }),
+    ).toThrow('payload-notifications: unknown channel "pigeon"')
+  })
+
+  it('throws for empty channels array', () => {
+    expect(() =>
+      normalizePluginOptions({
+        channels: [],
+      }),
+    ).toThrow('payload-notifications: at least one channel must be enabled')
   })
 })

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -124,4 +124,95 @@ describe('payload-notifications', () => {
     expect(queue).toHaveBeenCalledTimes(1)
     expect(sendEmail).toHaveBeenCalledTimes(1)
   })
+
+  it('registers live task handlers that work after onInit', async () => {
+    const queue = mock(async () => undefined)
+    const create = mock(async () => undefined)
+    const findByID = mock(async () => ({ id: 'user_1', email: 'demo@example.com' }))
+    const sendEmail = mock(async () => undefined)
+
+    const mockPayload = {
+      jobs: { queue },
+      create,
+      findByID,
+      sendEmail,
+    }
+
+    const plugin = notificationsPlugin({
+      rules: [
+        {
+          event: 'order.paid',
+          channels: ['email'],
+          template: 'order.paid',
+        },
+      ],
+    })
+
+    const config = plugin({ collections: [] })
+    const tasks = config.jobs && 'tasks' in config.jobs ? (config.jobs.tasks as any[]) : []
+
+    const processEventTask = tasks.find((t: any) => t.slug === 'notification:process-event')
+    const sendTask = tasks.find((t: any) => t.slug === 'notification:send')
+
+    expect(processEventTask).toBeTruthy()
+    expect(sendTask).toBeTruthy()
+
+    // Simulate Payload calling onInit
+    await config.onInit?.(mockPayload as never)
+
+    // Task handlers should now work without the deferred error
+    await processEventTask.handler({
+      input: { name: 'order.paid', userId: 'user_1' },
+    })
+
+    expect(queue).toHaveBeenCalledTimes(1)
+
+    await sendTask.handler({
+      input: {
+        userId: 'user_1',
+        channel: 'email',
+        template: 'order.paid',
+        event: 'order.paid',
+      },
+    })
+
+    expect(sendEmail).toHaveBeenCalledTimes(1)
+  })
+
+  it('task handlers fail gracefully before onInit', async () => {
+    const plugin = notificationsPlugin()
+    const config = plugin({ collections: [] })
+    const tasks = config.jobs && 'tasks' in config.jobs ? (config.jobs.tasks as any[]) : []
+
+    const processEventTask = tasks.find((t: any) => t.slug === 'notification:process-event')
+
+    // Call handler before onInit — should return failed state, not throw
+    const result = await processEventTask.handler({
+      input: { name: 'order.paid', userId: 'user_1' },
+    })
+
+    expect(result.state).toBe('failed')
+    expect(result.errorMessage).toContain('cannot run before plugin initialization')
+  })
+
+  it('preserves existing onInit hooks', async () => {
+    const existingOnInit = mock(async () => undefined)
+
+    const plugin = notificationsPlugin()
+    const config = plugin({
+      collections: [],
+      onInit: existingOnInit,
+    })
+
+    await config.onInit?.({} as never)
+    expect(existingOnInit).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls validateNormalizedOptions during plugin creation', () => {
+    expect(() =>
+      notificationsPlugin({
+        channels: [],
+      }),
+    ).toThrow('payload-notifications: at least one channel must be enabled')
+  })
 })

--- a/tests/sendNotification.test.ts
+++ b/tests/sendNotification.test.ts
@@ -87,4 +87,99 @@ describe('sendNotification', () => {
     expect(result?.status).toBe('stored')
     expect(create).toHaveBeenCalledTimes(2)
   })
+
+  it('persists resolved template title and message for in-app notifications', async () => {
+    const createCalls: any[] = []
+    const create = mock(async (args: any) => {
+      createCalls.push(args)
+      return undefined
+    })
+    const findByID = mock(async () => ({ id: 'user_1' }))
+    const payload = {
+      create,
+      findByID,
+    }
+
+    await sendNotification({
+      payload: payload as never,
+      input: {
+        userId: 'user_1',
+        channel: 'inapp',
+        template: 'order.paid',
+        event: 'order.paid',
+        eventPayload: { orderId: 'ORD-123' },
+      },
+      options: normalizePluginOptions(),
+    })
+
+    // First create call is the notification record
+    const notifData = createCalls[0]?.data
+    expect(notifData.title).toBe('Order paid')
+    expect(notifData.message).toBe('Order ORD-123 is now marked as paid.')
+  })
+
+  it('persists resolved template with token replacement for in-app', async () => {
+    const createCalls: any[] = []
+    const create = mock(async (args: any) => {
+      createCalls.push(args)
+      return undefined
+    })
+    const findByID = mock(async () => ({ id: 'user_1' }))
+    const payload = {
+      create,
+      findByID,
+    }
+
+    await sendNotification({
+      payload: payload as never,
+      input: {
+        userId: 'user_1',
+        channel: 'inapp',
+        template: 'order.shipped',
+        event: 'order.shipped',
+        eventPayload: { orderId: 'ORD-456' },
+      },
+      options: normalizePluginOptions(),
+    })
+
+    const notifData = createCalls[0]?.data
+    expect(notifData.title).toBe('Order shipped')
+    expect(notifData.message).toBe('Order ORD-456 has shipped.')
+  })
+
+  it('falls back to generic title when template has no title field', async () => {
+    const createCalls: any[] = []
+    const create = mock(async (args: any) => {
+      createCalls.push(args)
+      return undefined
+    })
+    const findByID = mock(async () => ({ id: 'user_1' }))
+    const payload = {
+      create,
+      findByID,
+    }
+
+    await sendNotification({
+      payload: payload as never,
+      input: {
+        userId: 'user_1',
+        channel: 'inapp',
+        template: 'custom.event',
+        event: 'custom.event',
+      },
+      options: normalizePluginOptions({
+        templates: {
+          registry: {
+            'custom.event': {
+              inapp: 'Simple body-only template for {{ event }}',
+            },
+          },
+        },
+      }),
+    })
+
+    const notifData = createCalls[0]?.data
+    expect(notifData.title).toBe('Notification: custom.event')
+    expect(notifData.message).toBe('Simple body-only template for custom.event')
+  })
 })


### PR DESCRIPTION
## Summary

Production-readiness improvements across task execution, template resolution, configuration validation, and documentation.

### Phase 1: Live task handlers (no more deferred errors)
- Task handlers are now wired via the plugin's `onInit` hook with a mutable runtime reference pattern
- Jobs execute immediately after Payload initialization without host-app overrides
- Slug deduplication is preserved — existing task definitions are respected
- Handlers return a clear error if called before `onInit` (instead of the generic deferred failure)

### Phase 2: In-app template resolution
- In-app notifications now persist resolved template `title` and `body` with full token replacement
- The orchestrator (`sendNotification.ts`) passes the resolved template definition to the in-app channel
- Falls back to generic `Notification: {event}` title if template has no `title` field

### Phase 3: Fail-fast configuration validation & safer defaults
- **BREAKING:** Default channels changed from `['email', 'whatsapp', 'sms', 'inapp']` to `['email', 'inapp']` — safe defaults that work without external providers
- **BREAKING:** Validation runs at plugin creation time, not at runtime
- New validations: unknown channels, empty channels array, SMS provider required, WhatsApp Twilio credentials
- All error messages use consistent `payload-notifications:` prefix

### Phase 4: Documentation
- README updated with jobs processing section, serverless constraints, migration guide from 0.1.x
- CHANGELOG updated with breaking changes and new features
- Template registry docs now explain in-app title/body resolution and token syntax

### Not included (follow-up)
- Real Twilio SMS/WhatsApp provider implementations (adapters remain mock — the provider adapter pattern is ready for drop-in replacement)
- Push channel implementation

## Files changed (10)

| File | Change |
|------|--------|
| `src/plugin.ts` | Live task handler registration via onInit, removed deferred handlers |
| `src/channels/inapp.ts` | Template resolution + token replacement for stored notifications |
| `src/jobs/sendNotification.ts` | Pass resolved template definition to in-app channel |
| `src/config/normalizePluginOptions.ts` | Safer defaults, comprehensive fail-fast validation |
| `tests/plugin.test.ts` | Tests for live handlers, pre-init failure, onInit chaining, validation |
| `tests/sendNotification.test.ts` | Tests for in-app template resolution and token replacement |
| `tests/channels.test.ts` | Tests for resolved in-app content, generic fallback |
| `tests/config.test.ts` | Tests for empty/unknown channels, SMS provider requirement |
| `README.md` | Jobs processing docs, serverless guidance, migration notes |
| `CHANGELOG.md` | Breaking changes and new features |

## Test plan

- [x] All 72 tests pass (`bun test`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Linter passes with only pre-existing warnings (`bun run lint`)
- [x] Live task handlers execute after simulated `onInit`
- [x] Task handlers return failed state before `onInit` (no crash)
- [x] Existing `onInit` hooks are preserved and chained
- [x] In-app notifications store resolved title "Order paid" and message with token replacement
- [x] In-app falls back to generic title when template has no `title` field
- [x] Empty channels array throws at creation time
- [x] Unknown channel names throw at creation time
- [x] SMS without provider throws at creation time
- [x] Default channels are `['email', 'inapp']`

---
🤖 *Generated by Computer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Default channels reduced to ['email','inapp']
  * Configuration validation runs at plugin creation and returns fail-fast errors prefixed with "payload-notifications:"
  * In-app notifications now persist resolved, token-replaced title/body

* **New Features**
  * Added job processing tasks for notifications
  * Task execution returns a failed result if invoked before plugin init

* **Documentation**
  * Updated README/CHANGELOG and migration notes
  * Documented template tokens: {{ event }}, {{ userId }}, {{ payload.key }}

* **Tests**
  * Added coverage for template resolution, validation, and task/init behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->