### PR TITLE
feat: Phase 1 MVP – DB-driven notification templates

### DIFF
--- a/src/collections/NotificationTemplates.ts
+++ b/src/collections/NotificationTemplates.ts
@@ -1,0 +1,51 @@
+import { CollectionConfig } from 'payload/types';
+
+export const NotificationTemplates: CollectionConfig = {
+  slug: 'notification-templates',
+  admin: { useAsTitle: 'name' },
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    { name: 'slug', type: 'text', required: true, unique: true },
+    { name: 'description', type: 'textarea' },
+    {
+      name: 'channels',
+      type: 'select',
+      hasMany: true,
+      options: ['email', 'sms', 'whatsapp', 'inapp'],
+    },
+    {
+      name: 'email',
+      type: 'group',
+      fields: [
+        { name: 'subject', type: 'text' },
+        { name: 'html', type: 'textarea' },
+        { name: 'text', type: 'textarea' },
+      ],
+    },
+    {
+      name: 'sms',
+      type: 'group',
+      fields: [{ name: 'body', type: 'textarea' }],
+    },
+    {
+      name: 'whatsapp',
+      type: 'group',
+      fields: [{ name: 'body', type: 'textarea' }],
+    },
+    {
+      name: 'inapp',
+      type: 'group',
+      fields: [
+        { name: 'title', type: 'text' },
+        { name: 'body', type: 'textarea' },
+      ],
+    },
+    { name: 'variables', type: 'json' },
+    {
+      name: 'status',
+      type: 'select',
+      defaultValue: 'draft',
+      options: ['draft', 'active'],
+    },
+  ],
+};

--- a/src/pipeline/useTemplate.ts
+++ b/src/pipeline/useTemplate.ts
@@ -1,0 +1,23 @@
+import { applyTemplate } from '../templates/applyTemplate';
+
+/**
+ * Wrapper to integrate templates into notification pipeline
+ */
+export const useTemplate = async ({
+  payload,
+  templateSlug,
+  channel,
+  data,
+  fallbackContent,
+}) => {
+  if (!templateSlug) return fallbackContent;
+
+  const rendered = await applyTemplate({
+    payload,
+    slug: templateSlug,
+    channel,
+    data,
+  });
+
+  return rendered || fallbackContent;
+};

--- a/src/templates/applyTemplate.ts
+++ b/src/templates/applyTemplate.ts
@@ -1,0 +1,21 @@
+import { renderTemplate } from './render';
+import { resolveTemplate } from './resolveTemplate';
+
+export const applyTemplate = async ({ payload, slug, channel, data }) => {
+  const tpl = await resolveTemplate({ payload, slug, channel });
+
+  if (!tpl) return null;
+
+  const result = {} as any;
+
+  for (const key in tpl) {
+    const value = tpl[key];
+    if (typeof value === 'string') {
+      result[key] = renderTemplate(value, data);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+};

--- a/src/templates/render.ts
+++ b/src/templates/render.ts
@@ -1,0 +1,5 @@
+export const renderTemplate = (template: string, data: Record<string, any>) => {
+  return template.replace(/{{(.*?)}}/g, (_, key) => {
+    return data[key.trim()] ?? '';
+  });
+};

--- a/src/templates/resolveTemplate.ts
+++ b/src/templates/resolveTemplate.ts
@@ -1,0 +1,34 @@
+import { Payload } from 'payload';
+
+export const resolveTemplate = async ({
+  payload,
+  slug,
+  channel,
+}: {
+  payload: Payload;
+  slug: string;
+  channel: string;
+}) => {
+  // 1. DB lookup
+  const res = await payload.find({
+    collection: 'notification-templates',
+    where: {
+      slug: { equals: slug },
+      status: { equals: 'active' },
+    },
+    limit: 1,
+  });
+
+  if (res.docs?.length) {
+    const tpl = res.docs[0] as any;
+    return tpl[channel] || null;
+  }
+
+  // 2. fallback (legacy)
+  try {
+    const { resolveFromRegistry } = await import('./resolve');
+    return resolveFromRegistry(slug, channel);
+  } catch (e) {
+    return null;
+  }
+};

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,0 +1,15 @@
+export type Channel = 'email' | 'sms' | 'whatsapp' | 'inapp';
+
+export interface TemplateRenderInput {
+  slug: string;
+  channel: Channel;
+  data: Record<string, any>;
+}
+
+export interface TemplateContent {
+  subject?: string;
+  html?: string;
+  text?: string;
+  body?: string;
+  title?: string;
+}


### PR DESCRIPTION
## 🚀 Phase 1 MVP – DB-driven Templates

Implements the first milestone from #30 by introducing database-driven templates with backward compatibility.

---

## ✅ Included

- `notification-templates` collection
- Basic `{{variable}}` interpolation renderer

---

## ❌ Next Steps

- DB-first template resolution
- Admin preview / send test
- Campaign system

---

## 🔗 Related

Partial implementation of #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification template management system supporting multiple channels: email, SMS, WhatsApp, and in-app messaging.
  * Template configurations include channel-specific customization with subjects, message bodies, and metadata.
  * Added template rendering utility enabling dynamic content personalization through variable substitution.
  * Templates support draft and active status states for workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->